### PR TITLE
Fix JS error handling

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -53,8 +53,12 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .then(response => response.json())
         .then(data => {
-            const formattedText = data.text.replace(/\n/g, '<br>');
-            outputArea.innerHTML = formattedText;
+            if (data.text) {
+                const formattedText = data.text.replace(/\n/g, '<br>');
+                outputArea.innerHTML = formattedText;
+            } else {
+                outputArea.textContent = 'Error: ' + (data.error || 'Unknown error');
+            }
             updateCounts();
         })
         .catch((error) => {


### PR DESCRIPTION
## Summary
- handle missing text errors in `script.js`

## Testing
- `python -m py_compile main.py getPdfUrl.py pdf_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_683bb6fd14608330960aa3db2b7e9d45